### PR TITLE
Spirit expanded subfunctions

### DIFF
--- a/examples/Spirit/run_spirit_squat.cc
+++ b/examples/Spirit/run_spirit_squat.cc
@@ -136,43 +136,22 @@ void runSpiritSquat(
   int num_legs = 4;
   double toeRadius = 0.02; // Radius of toe ball
   Vector3d toeOffset(toeRadius,0,0); // vector to "contact point"
+  double mu = 1; // Coeff of friction
   
 
+  int num_knotpoints_per_mode = 10; 
   
-  int num_knotpoints_per_mode = 10; // number of knot points in the collocation
 
   auto sequence = DirconModeSequence<T>(plant);
-  // std::vector<Eigen::Matrix<bool,1,4>> modes;
-  // std::vector<int> knotpoints;
-  // std::vector<Eigen::Vector3d> normals;
-  // std::vector<Eigen::Vector3d> offsets;
-  // std::vector<double> mus;
 
-  // Eigen::Matrix<bool,1,4> mode1;
-  // mode1 << 1, 1, 1, 1;
-
-  // int knots1 = 10;
-  
-  // Eigen::Vector3d normal1;
-  // normal1 << 0, 0, 1 ;
-  
-  // Eigen::Vector3d offset1;
-  // offset1 << 0, 0, 0 ;
-
-  // double mu1 = 1;
-
-  // modes.push_back(mode1);
-  // knotpoints.push_back(knots1);
-  // normals.push_back(normal1);
-  // offsets.push_back(offset1);
-  // mus.push_back(mu1);
   dairlib::ModeSequenceHelper msh;
+  
   msh.addMode( // FIRST MODE 1
-    (Eigen::Matrix<bool,1,4>() << 1,1,1,1 ).finished(), 
-    10, 
-    Eigen::Vector3d::UnitZ(), 
-    Eigen::Vector3d::Zero(), 
-    1 
+    (Eigen::Matrix<bool,1,4>() << 1,1,1,1 ).finished(), // contact bools 
+    num_knotpoints_per_mode,  // number of knot points in the collocation
+    Eigen::Vector3d::UnitZ(), // normal
+    Eigen::Vector3d::Zero(),  // world offset
+    mu //friction
     );
 
   auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, msh.modes , msh.knots , msh.normals , msh.offsets, msh.mus);
@@ -304,6 +283,7 @@ void runSpiritSquat(
   }
   setSpiritSymmetry(plant, trajopt, "sagittal");
   setSpiritJointLimits(plant, trajopt);
+  setSpiritActuationLimits(plant,trajopt);
 
  double upperLegLength = 0.206; // length of the upper leg link
 
@@ -417,6 +397,7 @@ int main(int argc, char* argv[]) {
 
   auto positions_map = dairlib::multibody::makeNameToPositionsMap(*plant);
   auto velocities_map = dairlib::multibody::makeNameToVelocitiesMap(*plant);
+  auto actuators_map = dairlib::multibody::makeNameToActuatorsMap(*plant);
   int num_joints = 12;
 
   // Print joint dictionary
@@ -424,6 +405,8 @@ int main(int argc, char* argv[]) {
   for (auto const& element : positions_map)
     std::cout << element.first << " = " << element.second << std::endl;
   for (auto const& element : velocities_map)
+    std::cout << element.first << " = " << element.second << std::endl;
+  for (auto const& element : actuators_map)
     std::cout << element.first << " = " << element.second << std::endl;
   std::cout<<"***************************************************"<<std::endl;
     

--- a/examples/Spirit/run_spirit_squat.cc
+++ b/examples/Spirit/run_spirit_squat.cc
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <gflags/gflags.h>
 #include <string.h>
+#include <assert.h>
 
 #include "drake/solvers/snopt_solver.h"
 #include "drake/systems/analysis/simulator.h"
@@ -66,7 +67,6 @@ using std::vector;
 using std::cout;
 using std::endl;
 
-
 template <typename T>
 void addConstraints(const MultibodyPlant<T>& plant, Dircon<T>& trajopt){
   // Get position and velocity dictionaries 
@@ -90,7 +90,6 @@ void addConstraints(const MultibodyPlant<T>& plant, Dircon<T>& trajopt){
 
   return;
 }
-
 
   /// See runSpiritSquat()
     // std::unique_ptr<MultibodyPlant<T>> plant_ptr,
@@ -135,12 +134,12 @@ void runSpiritSquat(
   
 
   
-  int num_knotpoints = 10; // number of knot points in the collocation
+  int num_knotpoints_per_mode = 10; // number of knot points in the collocation
 
   auto sequence = DirconModeSequence<T>(plant);
   Eigen::Matrix<bool,1,4> modeSeqMat;
   modeSeqMat << 1, 1, 1, 1;
-  Eigen::VectorXi knotpointMat = Eigen::MatrixXi::Constant(1,1,10);
+  Eigen::VectorXi knotpointMat = Eigen::MatrixXi::Constant(1,1,num_knotpoints_per_mode);
 
   auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, modeSeqMat , knotpointMat, mu);
   
@@ -187,6 +186,7 @@ void runSpiritSquat(
   }
 
   /// Setup all the optimization constraints 
+  int num_knotpoints = trajopt.N(); // number of knot points total in the collocation
   int n_v = plant.num_velocities();
   // int n_q = plant.num_positions();
   auto u = trajopt.input();
@@ -195,6 +195,7 @@ void runSpiritSquat(
   auto xmid = trajopt.state_vars(0, (num_knotpoints - 1) / 2);
   auto xf = trajopt.final_state();
   addConstraints(plant,trajopt);
+
   // // Initial body positions
   // trajopt.AddBoundingBoxConstraint(-FLAGS_eps, FLAGS_eps, x0(positions_map.at("base_x"))); // Give the initial condition room to choose the x_init position (helps with positive knee constraint)
   // trajopt.AddBoundingBoxConstraint(-FLAGS_eps, FLAGS_eps, x0(positions_map.at("base_y")));
@@ -259,66 +260,16 @@ void runSpiritSquat(
   trajopt.AddBoundingBoxConstraint(VectorXd::Zero(n_v), VectorXd::Zero(n_v),
                                    xf.tail(n_v));
 
-///////////////TODO/DEBUG
-  //   Might need this, but not sure. currently I personally parse this as constraining the first force_vars element
-  //     in the 0th mode to zero at all the knotpoints not sure why? 
-  // // Not sure what this is doing
-  // for (int i = 0; i < num_knotpoints; i++) {
-  //   trajopt.AddBoundingBoxConstraint(0, 0, trajopt.force_vars(0, i)(1));
-  // }
-//////////////TODO/DEBUG
-
-//   /// Find and constrain distances between toes
-//   // Distance evaluators for constraints (note one front back, one side to side, then symmetry)
-//   auto toe_dist_eval_front_back =  multibody::DistanceEvaluator<T>(plant, toeOffset, toe0_frontLeft, toeOffset, toe1_backLeft, FLAGS_front2BackToeDistance);
-//   auto toe_dist_eval_side_side  =  multibody::DistanceEvaluator<T>(plant, toeOffset, toe0_frontLeft, toeOffset, toe2_frontRight, FLAGS_side2SideToeDistance);
   
-//   auto toe_distance_evaluators = multibody::KinematicEvaluatorSet<T>(plant);
-//   toe_distance_evaluators.add_evaluator(&toe_dist_eval_front_back);
-//   toe_distance_evaluators.add_evaluator(&toe_dist_eval_side_side);
-//   // Allow a range of toe distances around the nominal
-//   auto toe_distance_lb = Eigen::VectorXd(2);
-//   auto toe_distance_ub = Eigen::VectorXd(2);
 
-//   toe_distance_lb(0) = -0.1;
-//   toe_distance_lb(1) = -0.1;
-//   toe_distance_ub(0) =  0.1;
-//   toe_distance_ub(1) =  0.1;
-//   // For toe distance constraints
-//   auto toe_constraints = std::make_shared<multibody::KinematicPositionConstraint<T>>(plant,
-//               toe_distance_evaluators, toe_distance_lb, toe_distance_ub);
-  
-//   // Implement toe distance constraints (if commented dist constraints not active)
-//   // for (int i = 0; i < num_knotpoints; i++){
-//   //   auto xi = trajopt.state(i);
-//   //   trajopt.AddConstraint(toe_constraints,xi.head(n_q));
-//   // }
-
-/// Symmetry constraints
   for (int i = 0; i < num_knotpoints; i++){
-    auto xi = trajopt.state(i);
-    //legs lined up (front and back hips equal)
-    trajopt.AddLinearConstraint( xi( positions_map.at("joint_8") ) ==  xi( positions_map.at("joint_9") ) );
-    trajopt.AddLinearConstraint( xi( positions_map.at("joint_10") ) ==  xi( positions_map.at("joint_11") ) );
-  
-    // Symmetry constraints (mirrored hips all else equal across)
-    trajopt.AddLinearConstraint( xi( positions_map.at("joint_8") ) == -xi( positions_map.at("joint_10") ) );
-    trajopt.AddLinearConstraint( xi( positions_map.at("joint_9") ) == -xi( positions_map.at("joint_11") ) );
-    // // Front legs equal and back legs equal constraints 
-    // trajopt.AddLinearConstraint( xi( positions_map.at("joint_0") ) == xi( positions_map.at("joint_4") ) );
-    // trajopt.AddLinearConstraint( xi( positions_map.at("joint_1") ) == xi( positions_map.at("joint_5") ) );
-    // trajopt.AddLinearConstraint( xi( positions_map.at("joint_2") ) == xi( positions_map.at("joint_6") ) );
-    // trajopt.AddLinearConstraint( xi( positions_map.at("joint_3") ) == xi( positions_map.at("joint_7") ) );
+    auto xi = trajopt.state(i);  
+    // legs lined up (front and back hips equal)
+    trajopt.AddLinearConstraint( xi( positions_map.at("joint_8") ) == xi( positions_map.at("joint_9") ) );
+    trajopt.AddLinearConstraint( xi( positions_map.at("joint_10") ) == xi( positions_map.at("joint_11") )  );
   }
-  for (int i = 0; i < trajopt.N(); i++){
-    auto xi = trajopt.state(i);
-    //legs lined up (front and back hips equal)
-    trajopt.AddBoundingBoxConstraint(-1.5, 1.5, xi( positions_map.at("joint_8")));
-    trajopt.AddBoundingBoxConstraint(-1.5, 1.5, xi( positions_map.at("joint_9")));
-    trajopt.AddBoundingBoxConstraint(-1.5, 1.5, xi( positions_map.at("joint_10")));
-    trajopt.AddBoundingBoxConstraint(-1.5, 1.5, xi( positions_map.at("joint_11")));
-
-  }
+  setSpiritSymmetry(plant, trajopt, "sagittal");
+  setSpiritJointLimits(plant, trajopt);
 
  double upperLegLength = 0.206; // length of the upper leg link
 
@@ -334,52 +285,6 @@ void runSpiritSquat(
   }catch(char const* exc){
       std::cerr<< exc <<std::endl;
   }
-
-/// Constraints for keeping "knees" above the floor 
-// Create the knee evaluators for non-linear constraint if necessary
-//   Vector3d kneeOffset(upperLegLength/2,0,0); // vector to "knee" point in upper leg frame
-//   std::vector<int> z_active({2});
-
-//   // Get frames (written out with to_string as reminder to functionalize)
-//   const auto& upper0_frontLeft  = plant.GetFrameByName( "upper" + std::to_string(0) );
-//   const auto& upper1_backLeft   = plant.GetFrameByName( "upper" + std::to_string(1) );
-//   const auto& upper2_frontRight = plant.GetFrameByName( "upper" + std::to_string(2) );
-//   const auto& upper3_backRight  = plant.GetFrameByName( "upper" + std::to_string(3) );
-//   // Make world point evaluators
-//   auto knee0z_eval = multibody::WorldPointEvaluator<T>(plant, kneeOffset, upper0_frontLeft , Matrix3d::Identity(), Vector3d::Zero(), z_active); //Shift to tip;
-//   auto knee1z_eval = multibody::WorldPointEvaluator<T>(plant, kneeOffset, upper1_backLeft  , Matrix3d::Identity(), Vector3d::Zero(), z_active); //Shift to tip;
-//   auto knee2z_eval = multibody::WorldPointEvaluator<T>(plant, kneeOffset, upper2_frontRight, Matrix3d::Identity(), Vector3d::Zero(), z_active); //Shift to tip;
-//   auto knee3z_eval = multibody::WorldPointEvaluator<T>(plant, kneeOffset, upper3_backRight , Matrix3d::Identity(), Vector3d::Zero(), z_active); //Shift to tip;
-//   // Consolidate evaluators
-//   auto knee_z_evaluators = multibody::KinematicEvaluatorSet<T>(plant); //Initialize kinematic evaluator set
-//   knee_z_evaluators.add_evaluator(&(knee0z_eval));
-//   knee_z_evaluators.add_evaluator(&(knee1z_eval));
-//   knee_z_evaluators.add_evaluator(&(knee2z_eval));
-//   knee_z_evaluators.add_evaluator(&(knee3z_eval));
-//   // Add lower bound on constraint
-//   auto knee_lb = Eigen::Vector4d(0, 0, 0, 0);
-//   auto knee_ub = 
-//           Eigen::Vector4d(std::numeric_limits<double>::infinity(), 
-//                           std::numeric_limits<double>::infinity(), 
-//                           std::numeric_limits<double>::infinity(), 
-//                           std::numeric_limits<double>::infinity());
-//   auto positive_knee_constraints =
-//       std::make_shared<multibody::KinematicPositionConstraint<T>>(
-//           plant, knee_z_evaluators, knee_lb, knee_ub);
-
-//   // Allow scaling of knee constraint (Not 100% on what this does)
-//   if (FLAGS_scale_constraint) {
-//     double scale = 1;
-//     std::unordered_map<int, double> odbp_constraint_scale;
-//     odbp_constraint_scale.insert(std::pair<int, double>(0, scale));
-//     odbp_constraint_scale.insert(std::pair<int, double>(1, scale));
-//     positive_knee_constraints->SetConstraintScaling(odbp_constraint_scale);
-//   }
-//   // Add positive knee constraint to all knot_points
-//   for (int i = 0; i < num_knotpoints; i++) {
-//     auto xi = trajopt.state(i);
-//     trajopt.AddConstraint(positive_knee_constraints, xi.head(n_q));
-//   }
 
   ///Setup the traditional cost function
   const double R = FLAGS_inputCost;  // Cost on input effort

--- a/examples/Spirit/run_spirit_squat.cc
+++ b/examples/Spirit/run_spirit_squat.cc
@@ -69,10 +69,6 @@ using std::cout;
 using std::endl;
 
 
-
-
-
-
 template <typename T>
 void addConstraints(const MultibodyPlant<T>& plant, Dircon<T>& trajopt){
   // Get position and velocity dictionaries 

--- a/examples/Spirit/run_spirit_squat.cc
+++ b/examples/Spirit/run_spirit_squat.cc
@@ -70,26 +70,6 @@ using std::endl;
 
 
 
-class ModeSequenceHelper {
-  public:
-    std::vector<Eigen::Matrix<bool,1,4>> modeSeqVect; // bool matrix describing toe contacts as true or false e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
-    std::vector<int> knotpointVect; // Matrix of knot points for each mode  
-    std::vector<Eigen::Vector3d> normals;
-    std::vector<Eigen::Vector3d> offsets;
-    std::vector<double> mus;
-    void addMode(
-      Eigen::Matrix<bool,1,4> activeContactVector, 
-      int num_knots, 
-      Eigen::Vector3d normal, 
-      Eigen::Vector3d offset,
-      double mu){
-        modeSeqVect.push_back(activeContactVector);
-        knotpointVect.push_back(num_knots);
-        normals.push_back(normal);
-        offsets.push_back(offset);
-        mus.push_back(mu);
-    }
-};
 
 
 
@@ -162,32 +142,40 @@ void runSpiritSquat(
   int num_knotpoints_per_mode = 10; // number of knot points in the collocation
 
   auto sequence = DirconModeSequence<T>(plant);
-  std::vector<Eigen::Matrix<bool,1,4>> modes;
-  std::vector<int> knotpoints;
-  std::vector<Eigen::Vector3d> normals;
-  std::vector<Eigen::Vector3d> offsets;
-  std::vector<double> mus;
+  // std::vector<Eigen::Matrix<bool,1,4>> modes;
+  // std::vector<int> knotpoints;
+  // std::vector<Eigen::Vector3d> normals;
+  // std::vector<Eigen::Vector3d> offsets;
+  // std::vector<double> mus;
 
-  Eigen::Matrix<bool,1,4> mode1;
-  mode1 << 1, 1, 1, 1;
+  // Eigen::Matrix<bool,1,4> mode1;
+  // mode1 << 1, 1, 1, 1;
 
-  int knots1 = 10;
+  // int knots1 = 10;
   
-  Eigen::Vector3d normal1;
-  normal1 << 0, 0, 1 ;
+  // Eigen::Vector3d normal1;
+  // normal1 << 0, 0, 1 ;
   
-  Eigen::Vector3d offset1;
-  offset1 << 0, 0, 0 ;
+  // Eigen::Vector3d offset1;
+  // offset1 << 0, 0, 0 ;
 
-  double mu1 = 1;
+  // double mu1 = 1;
 
-  modes.push_back(mode1);
-  knotpoints.push_back(knots1);
-  normals.push_back(normal1);
-  offsets.push_back(offset1);
-  mus.push_back(mu1);
+  // modes.push_back(mode1);
+  // knotpoints.push_back(knots1);
+  // normals.push_back(normal1);
+  // offsets.push_back(offset1);
+  // mus.push_back(mu1);
+  dairlib::ModeSequenceHelper msh;
+  msh.addMode( // FIRST MODE 1
+    (Eigen::Matrix<bool,1,4>() << 1,1,1,1 ).finished(), 
+    10, 
+    Eigen::Vector3d::UnitZ(), 
+    Eigen::Vector3d::Zero(), 
+    1 
+    );
 
-  auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, modes , knotpoints,normals, offsets, mus);
+  auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, msh.modes , msh.knots , msh.normals , msh.offsets, msh.mus);
   
   for (auto& mode : modeVector){
     for (int i = 0; i < num_legs; i++ ){

--- a/examples/Spirit/spirit_utils.cc
+++ b/examples/Spirit/spirit_utils.cc
@@ -248,8 +248,8 @@ void setSpiritJointLimits(drake::multibody::MultibodyPlant<T> & plant,
                           dairlib::systems::trajectory_optimization::Dircon<T>& trajopt ){
   // Upper doesn't need a joint limit for now, but we may eventually want to
   // change this to help the optimizations
-  double minValUpper = -M_PI ;
-  double maxValUpper =  M_PI ;
+  // double minValUpper = -M_PI ;
+  // double maxValUpper =  M_PI ;
 
   // Lower limits are set to 0 and pi in the URDF might be better to include
   // the few degrees that come with the body collision and to remove a few to stay
@@ -291,6 +291,27 @@ setSpiritJointLimits( plant,
 
 }
 //   \SETSPIRITJOINTLIMITS 
+
+
+// **********************************************************
+//   SETSPIRITACTUATIONLIMITS
+template <typename T>  
+void setSpiritActuationLimits(drake::multibody::MultibodyPlant<T> & plant, 
+                          dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
+                          double actuatorLimit){
+  auto actuators_map = multibody::makeNameToActuatorsMap(plant);
+  // std::cout<<"joint_" + std::to_string(iJoint)<<std::endl;
+  int N_knotpoints = trajopt.N();
+  for(int iKnot = 0; iKnot<N_knotpoints;iKnot++){
+    auto ui = trajopt.input(iKnot);
+    for (int iMotor = 0; iMotor<12; iMotor++){
+      trajopt.AddBoundingBoxConstraint(-actuatorLimit,actuatorLimit,ui(actuators_map.at("motor_" + std::to_string(iMotor))));
+    }
+  }
+
+}
+//   \SETSPIRITACTUATIONLIMITS
+
 
 // **********************************************************
 //   SETSPIRITSYMMETRY
@@ -427,6 +448,11 @@ template void setSpiritJointLimits(
 template void setSpiritJointLimits(
           drake::multibody::MultibodyPlant<double> & plant, 
           dairlib::systems::trajectory_optimization::Dircon<double>& trajopt );
+
+template void setSpiritActuationLimits(
+          drake::multibody::MultibodyPlant<double> & plant, 
+          dairlib::systems::trajectory_optimization::Dircon<double>& trajopt,
+          double actuatorLimit);
 
 template void setSpiritSymmetry(
         drake::multibody::MultibodyPlant<double> & plant, 

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -2,6 +2,27 @@
 
 namespace dairlib {
 
+class ModeSequenceHelper {
+  public:
+    std::vector<Eigen::Matrix<bool,1,4>> modes; // bool matrix describing toe contacts as true or false e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
+    std::vector<int> knots; // Matrix of knot points for each mode  
+    std::vector<Eigen::Vector3d> normals;
+    std::vector<Eigen::Vector3d> offsets;
+    std::vector<double> mus;
+    void addMode(
+      Eigen::Matrix<bool,1,4> activeContactVector, 
+      int num_knots, 
+      Eigen::Vector3d normal, 
+      Eigen::Vector3d offset,
+      double mu){
+        modes.push_back(activeContactVector);
+        knots.push_back(num_knots);
+        normals.push_back(normal);
+        offsets.push_back(offset);
+        mus.push_back(mu);
+    }
+};
+
 /// Outputs a nominal stand state into the xState vector pointer based on the 
 /// height. This is an approximation for use in initial conditions.
 ///   @param plant a pointer to the MultibodyPlant

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -37,11 +37,12 @@ const drake::multibody::Frame<T>& getSpiritToeFrame(
 template <typename T>
 std::unique_ptr<multibody::WorldPointEvaluator<T>> getSpiritToeEvaluator( 
                       drake::multibody::MultibodyPlant<T>& plant, 
+                      const Eigen::Vector3d toePoint,
                       u_int8_t toeIndex,
-                      const Eigen::Vector3d toePoint = Eigen::Vector3d::Zero(),
-                      double mu = 0.0,
                       const Eigen::Vector3d normal = Eigen::Vector3d::UnitZ(),
-                      bool xy_active = true
+                      const Eigen::Vector3d offset = Eigen::Vector3d::Zero(),
+                      bool xy_active = true, 
+                      double mu = 0.0
                       );
 
 
@@ -52,7 +53,7 @@ std::unique_ptr<multibody::WorldPointEvaluator<T>> getSpiritToeEvaluator(
 ///    @param plant a pointer to a multibodyPlant
 ///    @param modeSeqMat a bool matrix describing toe contacts as true or false 
 ///             e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
-///    @param knotpointMat  Vector of knot points for each mode  
+///    @param knotpointVect  Vector of knot points for each mode  
 ///    @param mu Friction coefficient
 
 template <typename T>
@@ -62,9 +63,11 @@ std::tuple<  std::vector<std::unique_ptr<dairlib::systems::trajectory_optimizati
           >     
     createSpiritModeSequence( 
           drake::multibody::MultibodyPlant<T>& plant, // multibodyPlant
-          Eigen::Matrix<bool,-1,4> modeSeqMat, // bool matrix describing toe contacts as true or false e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
-          Eigen::VectorXi knotpointMat, // Matrix of knot points for each mode  
-          double mu = 1);
+          std::vector<Eigen::Matrix<bool,1,4>> modeSeqVect, // bool matrix describing toe contacts as true or false e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
+          std::vector<int> knotpointVect, // Matrix of knot points for each mode  
+          std::vector<Eigen::Vector3d> normals,
+          std::vector<Eigen::Vector3d> offsets, 
+          std::vector<double> mus );
 
 
 

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -48,11 +48,12 @@ const drake::multibody::Frame<T>& getSpiritToeFrame(
 /// vector constructor to allow for non-world-aligned ground/surface contact.
 /// Also includes friction, and a offset from the frame if the toes have a radius
 ///   @param plant a point to the MultibodyPlant
-///   @param toeIndex the toeIndex of the desired evaluator
 ///   @param toePoint the toeOffset in the toe frame
-///   @param mu frictional coefficient
+///   @param toeIndex the toeIndex of the desired evaluator
 ///   @param normal the contact normal of this evaluator
+///   @param offset the contact normal's nominal location in the world
 ///   @param xy_active are the tangent directions active
+///   @param mu frictional coefficient
 ///              )
 ///
 template <typename T>
@@ -75,7 +76,9 @@ std::unique_ptr<multibody::WorldPointEvaluator<T>> getSpiritToeEvaluator(
 ///    @param modeSeqMat a bool matrix describing toe contacts as true or false 
 ///             e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
 ///    @param knotpointVect  Vector of knot points for each mode  
-///    @param mu Friction coefficient
+///    @param normals vector of contact normals of each mode
+///    @param offsets vector of contact normals' nominal locations in the world
+///    @param mus vector of friction coefficients
 
 template <typename T>
 std::tuple<  std::vector<std::unique_ptr<dairlib::systems::trajectory_optimization::DirconMode<T>>>,
@@ -92,15 +95,12 @@ std::tuple<  std::vector<std::unique_ptr<dairlib::systems::trajectory_optimizati
 
 
 
-/// Add joint kinematic limits to the spirit joints
-
-// template <typename T>
-// void setSpiritJointLimits(
-//     drake::multibody::MultibodyPlant<T> & plant
-// )
-
-
-
+/// This overload sets an individual joint's position limit
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
+///    @param iJoint the integer index of the joint
+///    @param minVal joint's minimum position
+///    @param minVal joint's maximum position
 template <typename T>
 void setSpiritJointLimits(
                     drake::multibody::MultibodyPlant<T> & plant, 
@@ -109,6 +109,12 @@ void setSpiritJointLimits(
                     double minVal, 
                     double maxVal  );
 
+/// This overload sets an a set of joints' position limits
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
+///    @param iJoints the integer indices (vector) of the joints to be limited
+///    @param minVals vector of joints' minimum positions
+///    @param minVals vector of joints' maximum positions
 template <typename T>
 void setSpiritJointLimits(
                     drake::multibody::MultibodyPlant<T> & plant, 
@@ -117,6 +123,12 @@ void setSpiritJointLimits(
                     std::vector<double> minVals, 
                     std::vector<double> maxVals  );
 
+/// This overload sets an a set of joints' position limits to the same thing
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
+///    @param iJoints the integer indices (vector) of the joints to be limited
+///    @param minVal joints' minimum position
+///    @param minVal joints' maximum position
 template <typename T>
 void setSpiritJointLimits(
                     drake::multibody::MultibodyPlant<T> & plant, 
@@ -125,24 +137,41 @@ void setSpiritJointLimits(
                     double minVal, 
                     double maxVal  );
 
+/// This overload sets all the joints to their nominal limit's
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
 template <typename T>
 void setSpiritJointLimits(
                     drake::multibody::MultibodyPlant<T> & plant, 
                     dairlib::systems::trajectory_optimization::Dircon<T>& trajopt );
 
 
+/// Sets all the joints' actuator limits to the same thing
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
+///    @param actuatorLimit the (symmetric) effort limit 
 template <typename T> 
 void setSpiritActuationLimits(
           drake::multibody::MultibodyPlant<T> & plant, 
           dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
           double actuatorLimit = 40.0);//From URDF this default seems a bit high
 
+/// Constrains the system to a single symmetric leg behavior
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
+///    @param symmetry a string of the desired symmetry
 template <typename T> 
 void setSpiritSymmetry(
         drake::multibody::MultibodyPlant<T> & plant, 
         dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
         std::string symmetry = "sagittal");
 
+
+/// Constrains the system to a set symmetric leg behaviors handling internal
+/// over contraining (TODO)
+///    @param plant a pointer to a multibodyPlant
+///    @param trajopt a ponter to a Dircon<T> object  
+///    @param symmetry a vector of symmetries (vector)
 template <typename T>
 void setSpiritSymmetry(
         drake::multibody::MultibodyPlant<T> & plant, 

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -66,5 +66,56 @@ std::tuple<  std::vector<std::unique_ptr<dairlib::systems::trajectory_optimizati
           Eigen::VectorXi knotpointMat, // Matrix of knot points for each mode  
           double mu = 1);
 
-}
 
+
+/// Add joint kinematic limits to the spirit joints
+
+// template <typename T>
+// void setSpiritJointLimits(
+//     drake::multibody::MultibodyPlant<T> & plant
+// )
+
+
+
+template <typename T>
+void setSpiritJointLimits(
+                    drake::multibody::MultibodyPlant<T> & plant, 
+                    dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,  
+                    int iJoint, 
+                    double minVal, 
+                    double maxVal  );
+
+template <typename T>
+void setSpiritJointLimits(
+                    drake::multibody::MultibodyPlant<T> & plant, 
+                    dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,  
+                    std::vector<int> iJoints, 
+                    std::vector<double> minVals, 
+                    std::vector<double> maxVals  );
+
+template <typename T>
+void setSpiritJointLimits(
+                    drake::multibody::MultibodyPlant<T> & plant, 
+                    dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,  
+                    std::vector<int> iJoints, 
+                    double minVal, 
+                    double maxVal  );
+
+template <typename T>
+void setSpiritJointLimits(
+                    drake::multibody::MultibodyPlant<T> & plant, 
+                    dairlib::systems::trajectory_optimization::Dircon<T>& trajopt );
+
+template <typename T> 
+void setSpiritSymmetry(
+        drake::multibody::MultibodyPlant<T> & plant, 
+        dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
+        std::string symmetry = "sagittal");
+
+template <typename T>
+void setSpiritSymmetry(
+        drake::multibody::MultibodyPlant<T> & plant, 
+        dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
+        std::vector<std::string> symmetries);
+
+} //namespace dairlib

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -154,7 +154,7 @@ template <typename T>
 void setSpiritActuationLimits(
           drake::multibody::MultibodyPlant<T> & plant, 
           dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
-          double actuatorLimit = 40.0);//From URDF this default seems a bit high
+          double actuatorLimit = 3.5 * 6);// URDF has 40 this is more realistic based on the modules 
 
 /// Constrains the system to a single symmetric leg behavior
 ///    @param plant a pointer to a multibodyPlant
@@ -164,7 +164,8 @@ template <typename T>
 void setSpiritSymmetry(
         drake::multibody::MultibodyPlant<T> & plant, 
         dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
-        std::string symmetry = "sagittal");
+        std::string symmetry = "sagittal",
+        bool ignoreWarning = false);
 
 
 /// Constrains the system to a set symmetric leg behaviors handling internal

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -130,6 +130,13 @@ void setSpiritJointLimits(
                     drake::multibody::MultibodyPlant<T> & plant, 
                     dairlib::systems::trajectory_optimization::Dircon<T>& trajopt );
 
+
+template <typename T> 
+void setSpiritActuationLimits(
+          drake::multibody::MultibodyPlant<T> & plant, 
+          dairlib::systems::trajectory_optimization::Dircon<T>& trajopt,
+          double actuatorLimit = 40.0);//From URDF this default seems a bit high
+
 template <typename T> 
 void setSpiritSymmetry(
         drake::multibody::MultibodyPlant<T> & plant, 


### PR DESCRIPTION
Added Joint position limits, sagittal symmetry, joint effort limits, a class for building modes, normal/offset handling for contact surfaces. 

Joint velocity limits might also be another nice thing to add. The joint effort limits function is very rudimentary and the default value is set based on the URDF which may be over estimating it . Should probably at least add a vector version for consistency and future flexibility, ALSO this is assuming just the legs (not any future added DoFs) and that the effort is the same for all of them, assuming mechanical reduction isn't included this is not true and should be fixed to better exemplify the real robot. 
