### PR TITLE
Minor changes to utils.

### DIFF
--- a/examples/Spirit/run_spirit_squat.cc
+++ b/examples/Spirit/run_spirit_squat.cc
@@ -150,7 +150,8 @@ void runSpiritSquat(
     mu //friction
     );
 
-  auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, msh.modes , msh.knots , msh.normals , msh.offsets, msh.mus);
+  // auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, msh.modes , msh.knots , msh.normals , msh.offsets, msh.mus, msh.minTs, msh.maxTs);
+  auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, &msh);
   
   for (auto& mode : modeVector){
     for (int i = 0; i < num_legs; i++ ){

--- a/examples/Spirit/run_spirit_squat.cc
+++ b/examples/Spirit/run_spirit_squat.cc
@@ -151,7 +151,7 @@ void runSpiritSquat(
     );
 
   // auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, msh.modes , msh.knots , msh.normals , msh.offsets, msh.mus, msh.minTs, msh.maxTs);
-  auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, &msh);
+  auto [modeVector, toeEvals, toeEvalSets] = createSpiritModeSequence(plant, msh);
   
   for (auto& mode : modeVector){
     for (int i = 0; i < num_legs; i++ ){

--- a/examples/Spirit/spirit_utils.cc
+++ b/examples/Spirit/spirit_utils.cc
@@ -175,9 +175,9 @@ std::tuple<
                 std::vector<std::unique_ptr<dairlib::multibody::KinematicEvaluatorSet<T>>>
           > createSpiritModeSequence( 
           MultibodyPlant<T>& plant, // multibodyPlant
-          dairlib::ModeSequenceHelper* msh ){
+          const dairlib::ModeSequenceHelper& msh ){
 
-return createSpiritModeSequence(plant, msh->modes , msh->knots , msh->normals , msh->offsets, msh->mus, msh->minTs, msh->maxTs);
+return createSpiritModeSequence(plant, msh.modes , msh.knots , msh.normals , msh.offsets, msh.mus, msh.minTs, msh.maxTs);
 }
 
 
@@ -451,7 +451,7 @@ template std::tuple<
                 std::vector<std::unique_ptr<dairlib::multibody::KinematicEvaluatorSet<double>>>
           > createSpiritModeSequence( 
           MultibodyPlant<double>& plant, // multibodyPlant
-          dairlib::ModeSequenceHelper* msh );//NOLINT
+          const dairlib::ModeSequenceHelper& msh );//NOLINT
           
   
 template void setSpiritJointLimits(

--- a/examples/Spirit/spirit_utils.cc
+++ b/examples/Spirit/spirit_utils.cc
@@ -127,7 +127,9 @@ std::tuple<
           std::vector<int> knotpointVect, // Matrix of knot points for each mode  
           std::vector<Eigen::Vector3d> normals,
           std::vector<Eigen::Vector3d> offsets, 
-          std::vector<double> mus ){
+          std::vector<double> mus, 
+          std::vector<double> minTs, 
+          std::vector<double> maxTs ){
 
   // std::cout<<modeSeqMat<<std::endl;
   // std::cout<<knotpointVect<<std::endl;  
@@ -149,13 +151,13 @@ std::tuple<
     toeEvalSets.push_back( std::move( std::make_unique<dairlib::multibody::KinematicEvaluatorSet<T>>(plant) ));
     for ( int iLeg = 0; iLeg < 4; iLeg++ ){
       if (modeSeqVect.at(iMode)(iLeg)){
-        toeEvals.push_back( std::move( getSpiritToeEvaluator(plant, toeOffset, iLeg, normals.at(iMode), offsets.at(iMode), mus.at(iMode) )) );//Default Normal (z), offset, and xy_active=true
+        toeEvals.push_back( std::move( getSpiritToeEvaluator(plant, toeOffset, iLeg, normals.at(iMode), offsets.at(iMode), true, mus.at(iMode) )) );
         (toeEvalSets.back())->add_evaluator(  (toeEvals.back()).get()  ); //add evaluator to the set if active //Works ish
       }
     }
     auto dumbToeEvalPtr = (toeEvalSets.back()).get() ;
     int num_knotpoints = knotpointVect.at(iMode);
-    modeVector.push_back(std::move( std::make_unique<DirconMode<T>>( *dumbToeEvalPtr , num_knotpoints )));
+    modeVector.push_back(std::move( std::make_unique<DirconMode<T>>( *dumbToeEvalPtr , num_knotpoints, minTs.at(iMode), maxTs.at(iMode) )));
     // DirconMode<T> modeDum = DirconMode<T>( *dumbToeEvalPtr , num_knotpoints );
     // sequence.AddMode(  &modeDum  ); // Add the evaluator set to the mode sequence
     
@@ -164,28 +166,19 @@ std::tuple<
   return {std::move(modeVector), std::move(toeEvals), std::move(toeEvalSets)};
   // return {std::move(toeEvals), std::move(toeEvalSets)};
 }
-// //Overload function to allow the use of a equal number of knotpoints for every mode.
-// template <typename T>
-// std::tuple<
-//                 DirconModeSequence<T>,
-//                 std::vector<std::unique_ptr<multibody::WorldPointEvaluator<T>>> ,
-//                 std::vector<std::unique_ptr<multibody::KinematicEvaluatorSet<T>>>
-//           > createSpiritModeSequence( 
-//   MultibodyPlant<T>& plant, // multibodyPlant
-//   Eigen::Matrix<bool,-1,4> modeSeqMat, // bool matrix describing toe contacts as true or false e.g. {{1,1,1,1},{0,0,0,0}} would be a full support mode and flight mode
-//   uint16_t knotpoints, // Number of knot points per mode
-//   double mu = 1){
-//   int numModes = modeSeqMat.rows(); 
-//   std::vector<int> knotpointVect = Eigen::MatrixXi::Constant(numModes,1,knotpoints);
-//   return createSpiritModeSequence(plant, modeSeqMat,knotpointVect, mu);
-// }
 
 
+template <typename T>
+std::tuple<
+                std::vector<std::unique_ptr<DirconMode<T>>>,
+                std::vector<std::unique_ptr<dairlib::multibody::WorldPointEvaluator<T>>> ,
+                std::vector<std::unique_ptr<dairlib::multibody::KinematicEvaluatorSet<T>>>
+          > createSpiritModeSequence( 
+          MultibodyPlant<T>& plant, // multibodyPlant
+          dairlib::ModeSequenceHelper* msh ){
 
-
-
-
-
+return createSpiritModeSequence(plant, msh->modes , msh->knots , msh->normals , msh->offsets, msh->mus, msh->minTs, msh->maxTs);
+}
 
 
 
@@ -447,7 +440,18 @@ template std::tuple<  std::vector<std::unique_ptr<dairlib::systems::trajectory_o
           std::vector<int> knotpointVect, // Matrix of knot points for each mode  
           std::vector<Eigen::Vector3d> normals,
           std::vector<Eigen::Vector3d> offsets, 
-          std::vector<double> mus ); // NOLINT
+          std::vector<double> mus , 
+          std::vector<double> minTs, 
+          std::vector<double> maxTs); // NOLINT
+          
+
+template std::tuple<
+                std::vector<std::unique_ptr<DirconMode<double>>>,
+                std::vector<std::unique_ptr<dairlib::multibody::WorldPointEvaluator<double>>> ,
+                std::vector<std::unique_ptr<dairlib::multibody::KinematicEvaluatorSet<double>>>
+          > createSpiritModeSequence( 
+          MultibodyPlant<double>& plant, // multibodyPlant
+          dairlib::ModeSequenceHelper* msh );//NOLINT
           
   
 template void setSpiritJointLimits(

--- a/examples/Spirit/spirit_utils.h
+++ b/examples/Spirit/spirit_utils.h
@@ -109,7 +109,7 @@ std::tuple<  std::vector<std::unique_ptr<dairlib::systems::trajectory_optimizati
           >     
     createSpiritModeSequence( 
           drake::multibody::MultibodyPlant<T>& plant, // multibodyPlant
-          dairlib::ModeSequenceHelper* msh );
+          const dairlib::ModeSequenceHelper& msh );
 
 /// This overload sets all the joints to their nominal limit's
 ///    @param plant a pointer to a multibodyPlant


### PR DESCRIPTION
 Added minimum/maxium times for the modes, added a overload to pass in the msh object instead of individual vectors. Squat now uses latest interface. Fixed bug that caused friction to be zero (wrong amount of arguments to getSpiritToeEvalutator).